### PR TITLE
获得焦点事件改到onMouseDown

### DIFF
--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -29,7 +29,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
 
   const containerRef = useRef<HTMLSpanElement>(null);
 
-  const onInputMouseUp: React.MouseEventHandler = (e) => {
+  const onInputMouseDown: React.MouseEventHandler = (e) => {
     if (containerRef.current?.contains(e.target as Element)) {
       triggerFocus?.();
     }
@@ -98,7 +98,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
         className={affixWrapperCls}
         style={style}
         hidden={!hasAddon(props) && hidden}
-        onMouseUp={onInputMouseUp}
+        onMouseDown={onInputMouseDown}
         ref={containerRef}
       >
         {prefix && <span className={`${prefixCls}-prefix`}>{prefix}</span>}


### PR DESCRIPTION
[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

####   需求背景：多个input输入框并列场景（如：可编辑表格），使用鼠标选择input中内容，如果最后mouseup的时候鼠标在另一个移到另一个输入框，则会触发鼠标所在位置input的获取焦点事件，从而导致框选内容操作失败

####  解决方案：把获取焦点事件由mouseup 换成mousedown

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     In the case of hasprefixsuffix, the focus acquisition event of input is triggered, which is triggered by the MouseUp event instead of the MouseDown event     |
| 🇨🇳 中文 |    hasPrefixSuffix的情况下，input的获取焦点事件触发，由mouseUp改为mouseDown事件触发      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供