### PR TITLE
fix(): :bug: 点击prefix或suffix无法获取焦点

### DIFF
--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -29,7 +29,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
 
   const containerRef = useRef<HTMLSpanElement>(null);
 
-  const onInputMouseDown: React.MouseEventHandler = (e) => {
+  const onInputMouseUp: React.MouseEventHandler = (e) => {
     if (containerRef.current?.contains(e.target as Element)) {
       triggerFocus?.();
     }
@@ -98,7 +98,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
         className={affixWrapperCls}
         style={style}
         hidden={!hasAddon(props) && hidden}
-        onMouseDown={onInputMouseDown}
+        onMouseUp={onInputMouseUp}
         ref={containerRef}
       >
         {prefix && <span className={`${prefixCls}-prefix`}>{prefix}</span>}

--- a/tests/BaseInput.test.tsx
+++ b/tests/BaseInput.test.tsx
@@ -126,7 +126,7 @@ describe('BaseInput', () => {
         prefix="$"
       />,
     );
-    fireEvent.mouseDown(container.querySelector('.rc-input-affix-wrapper')!);
+    fireEvent.mouseUp(container.querySelector('.rc-input-affix-wrapper')!);
     expect(document.activeElement).toBe(container.querySelector('input'));
   });
 });


### PR DESCRIPTION


[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

点击`prefix`或者`suffix`不会获取输入框的焦点。  
打印`console`发现其同时触发了`focus`和`blur`事件。  

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
