### PR TITLE
fix(): :bug: 点击prefix或suffix无法获取焦点

### DIFF
--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -2,9 +2,7 @@ import type { FC, ReactElement } from 'react';
 import React, { cloneElement, useRef } from 'react';
 import classNames from 'classnames';
 import type { BaseInputProps } from './interface';
-import { hasAddon, hasPrefixSuffix, uniqueId } from './utils/commonUtils';
-
-let isMouseDown: null | string = null;
+import { hasAddon, hasPrefixSuffix } from './utils/commonUtils';
 
 const BaseInput: FC<BaseInputProps> = (props) => {
   const {
@@ -30,20 +28,11 @@ const BaseInput: FC<BaseInputProps> = (props) => {
   } = props;
 
   const containerRef = useRef<HTMLSpanElement>(null);
-  const containerId = useRef(uniqueId());
 
-  const onInputMouseUp: React.MouseEventHandler = (e) => {
-    if (
-      containerRef.current?.contains(e.target as Element) &&
-      (isMouseDown === null || isMouseDown === containerId.current)
-    ) {
+  const onInputClick: React.MouseEventHandler = (e) => {
+    if (containerRef.current?.contains(e.target as Element)) {
       triggerFocus?.();
     }
-    isMouseDown = null;
-  };
-
-  const onInputMouseDown: React.MouseEventHandler = (e) => {
-    isMouseDown = containerId.current;
   };
 
   // ================== Clear Icon ================== //
@@ -109,8 +98,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
         className={affixWrapperCls}
         style={style}
         hidden={!hasAddon(props) && hidden}
-        onMouseDown={onInputMouseDown}
-        onMouseUp={onInputMouseUp}
+        onClick={onInputClick}
         ref={containerRef}
       >
         {prefix && <span className={`${prefixCls}-prefix`}>{prefix}</span>}

--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -2,7 +2,9 @@ import type { FC, ReactElement } from 'react';
 import React, { cloneElement, useRef } from 'react';
 import classNames from 'classnames';
 import type { BaseInputProps } from './interface';
-import { hasAddon, hasPrefixSuffix } from './utils/commonUtils';
+import { hasAddon, hasPrefixSuffix, uniqueId } from './utils/commonUtils';
+
+let isMouseDown: null | string = null;
 
 const BaseInput: FC<BaseInputProps> = (props) => {
   const {
@@ -28,11 +30,20 @@ const BaseInput: FC<BaseInputProps> = (props) => {
   } = props;
 
   const containerRef = useRef<HTMLSpanElement>(null);
+  const containerId = useRef(uniqueId());
 
-  const onInputMouseDown: React.MouseEventHandler = (e) => {
-    if (containerRef.current?.contains(e.target as Element)) {
+  const onInputMouseUp: React.MouseEventHandler = (e) => {
+    if (
+      containerRef.current?.contains(e.target as Element) &&
+      (isMouseDown === null || isMouseDown === containerId.current)
+    ) {
       triggerFocus?.();
     }
+    isMouseDown = null;
+  };
+
+  const onInputMouseDown: React.MouseEventHandler = (e) => {
+    isMouseDown = containerId.current;
   };
 
   // ================== Clear Icon ================== //
@@ -99,6 +110,7 @@ const BaseInput: FC<BaseInputProps> = (props) => {
         style={style}
         hidden={!hasAddon(props) && hidden}
         onMouseDown={onInputMouseDown}
+        onMouseUp={onInputMouseUp}
         ref={containerRef}
       >
         {prefix && <span className={`${prefixCls}-prefix`}>{prefix}</span>}

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -1,6 +1,23 @@
 import type { BaseInputProps, InputProps } from '../interface';
 import type React from 'react';
 
+const idCounter: {
+  [key: string]: number;
+} = {};
+
+export function uniqueId(prefix = '$rc-input$') {
+  if (!idCounter[prefix]) {
+    idCounter[prefix] = 0;
+  }
+
+  const id = ++idCounter[prefix];
+  if (prefix === '$lodash$') {
+    return `${id}`;
+  }
+
+  return `${prefix}${id}`;
+}
+
 export function hasAddon(props: BaseInputProps | InputProps) {
   return !!(props.addonBefore || props.addonAfter);
 }

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -1,23 +1,6 @@
 import type { BaseInputProps, InputProps } from '../interface';
 import type React from 'react';
 
-const idCounter: {
-  [key: string]: number;
-} = {};
-
-export function uniqueId(prefix = '$rc-input$') {
-  if (!idCounter[prefix]) {
-    idCounter[prefix] = 0;
-  }
-
-  const id = ++idCounter[prefix];
-  if (prefix === '$lodash$') {
-    return `${id}`;
-  }
-
-  return `${prefix}${id}`;
-}
-
 export function hasAddon(props: BaseInputProps | InputProps) {
   return !!(props.addonBefore || props.addonAfter);
 }

--- a/tests/BaseInput.test.tsx
+++ b/tests/BaseInput.test.tsx
@@ -126,7 +126,7 @@ describe('BaseInput', () => {
         prefix="$"
       />,
     );
-    fireEvent.mouseUp(container.querySelector('.rc-input-affix-wrapper')!);
+    fireEvent.click(container.querySelector('.rc-input-affix-wrapper')!);
     expect(document.activeElement).toBe(container.querySelector('input'));
   });
 });

--- a/tests/BaseInput.test.tsx
+++ b/tests/BaseInput.test.tsx
@@ -126,7 +126,7 @@ describe('BaseInput', () => {
         prefix="$"
       />,
     );
-    fireEvent.mouseDown(container.querySelector('.rc-input-affix-wrapper')!);
+    fireEvent.mouseUp(container.querySelector('.rc-input-affix-wrapper')!);
     expect(document.activeElement).toBe(container.querySelector('input'));
   });
 });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close https://github.com/ant-design/ant-design/issues/38169

### 💡 需求背景和解决方案

点击`prefix`或者`suffix`不会获取输入框的焦点。  
打印`console`发现其同时触发了`focus`和`blur`事件。    
承接之前一次错误的[PR](https://github.com/react-component/input/pull/23)。  
考虑到此[PR](https://github.com/react-component/input/pull/13)中提到的问题做了**兼容**。  

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
