### PR TITLE
chore: add value type

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -110,23 +110,28 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const getInputElement = () => {
     // Fix https://fb.me/react-unknown-prop
-    const otherProps = omit(props as InputProps, [
-      'prefixCls',
-      'onPressEnter',
-      'addonBefore',
-      'addonAfter',
-      'prefix',
-      'suffix',
-      'allowClear',
-      // Input elements must be either controlled or uncontrolled,
-      // specify either the value prop, or the defaultValue prop, but not both.
-      'defaultValue',
-      'showCount',
-      'classes',
-      'htmlSize',
-      'styles',
-      'classNames',
-    ]);
+    const otherProps = omit(
+      props as Omit<InputProps, 'value'> & {
+        value?: React.InputHTMLAttributes<HTMLInputElement>['value'];
+      },
+      [
+        'prefixCls',
+        'onPressEnter',
+        'addonBefore',
+        'addonAfter',
+        'prefix',
+        'suffix',
+        'allowClear',
+        // Input elements must be either controlled or uncontrolled,
+        // specify either the value prop, or the defaultValue prop, but not both.
+        'defaultValue',
+        'showCount',
+        'classes',
+        'htmlSize',
+        'styles',
+        'classNames',
+      ],
+    );
     return (
       <input
         autoComplete={autoComplete}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -35,8 +35,10 @@ export interface CommonInputProps {
 
 type DataAttr = Record<`data-${string}`, string>;
 
+export type ValueType = InputHTMLAttributes<HTMLInputElement>['value'] | bigint;
+
 export interface BaseInputProps extends CommonInputProps {
-  value?: InputHTMLAttributes<HTMLInputElement>['value'];
+  value?: ValueType;
   inputElement: ReactElement;
   prefixCls?: string;
   className?: string;
@@ -68,7 +70,11 @@ export interface ShowCountProps {
 
 export interface InputProps
   extends CommonInputProps,
-    Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'prefix' | 'type'> {
+    Omit<
+      InputHTMLAttributes<HTMLInputElement>,
+      'size' | 'prefix' | 'type' | 'value'
+    > {
+  value?: ValueType;
   prefixCls?: string;
   // ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#%3Cinput%3E_types
   type?: LiteralUnion<

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -75,6 +75,10 @@ describe('Input', () => {
     await user.click(container.querySelector('.rc-input-clear-icon')!);
     expect(document.activeElement).toBe(container.querySelector('input'));
   });
+
+  it('support bigint type', () => {
+    expect(<Input value={BigInt('2222')} />).toBeTruthy();
+  });
 });
 
 describe('should support showCount', () => {


### PR DESCRIPTION
`bigint` is validate `value` type in React usage also: https://codesandbox.io/s/ji-ben-shi-yong-antd-5-9-1-forked-v5d5j4?file=/demo.tsx