### PR TITLE
feat: add `count` for customize count logic

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -1,4 +1,8 @@
 .rc-input {
+  &-out-of-range {
+    color: red;
+  }
+
   &-affix-wrapper {
     padding: 2px 8px;
     overflow: hidden;

--- a/docs/examples/show-count.tsx
+++ b/docs/examples/show-count.tsx
@@ -13,15 +13,48 @@ const Demo: FC = () => {
         alignItems: 'start',
       }}
     >
+      <h1>Native</h1>
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" />
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" maxLength={20} />
+      <h1>Count</h1>
+      <h4>Only Max</h4>
       <Input
+        placeholder="count.max"
         prefixCls="rc-input"
-        defaultValue="👨‍👩‍👧‍👦"
+        defaultValue="🔥"
         count={{
           show: true,
+          max: 5,
+        }}
+      />
+      <h4>Customize strategy</h4>
+      <Input
+        placeholder="Emoji count 1"
+        prefixCls="rc-input"
+        defaultValue="🔥"
+        count={{
+          show: true,
+          max: 5,
           strategy: (val) =>
             [...new (Intl as any).Segmenter().segment(val)].length,
+        }}
+      />
+      <h4>Customize exceedFormatter</h4>
+      <Input
+        placeholder="Emoji count 1"
+        prefixCls="rc-input"
+        defaultValue="🔥"
+        count={{
+          show: true,
+          max: 5,
+          exceedFormatter: (val, { max }) => {
+            const segments = [...new (Intl as any).Segmenter().segment(val)];
+
+            return segments
+              .filter((seg) => seg.index + seg.segment.length <= max)
+              .map((seg) => seg.segment)
+              .join('');
+          },
         }}
       />
     </div>

--- a/docs/examples/show-count.tsx
+++ b/docs/examples/show-count.tsx
@@ -15,6 +15,15 @@ const Demo: FC = () => {
     >
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" />
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" maxLength={20} />
+      <Input
+        prefixCls="rc-input"
+        defaultValue="👨‍👩‍👧‍👦"
+        count={{
+          show: true,
+          strategy: (val) =>
+            [...new (Intl as any).Segmenter().segment(val)].length,
+        }}
+      />
     </div>
   );
 };

--- a/docs/examples/show-count.tsx
+++ b/docs/examples/show-count.tsx
@@ -3,6 +3,11 @@ import type { FC } from 'react';
 import React from 'react';
 import '../../assets/index.less';
 
+const sharedHeadStyle: React.CSSProperties = {
+  margin: 0,
+  padding: 0,
+};
+
 const Demo: FC = () => {
   return (
     <div
@@ -13,11 +18,11 @@ const Demo: FC = () => {
         alignItems: 'start',
       }}
     >
-      <h1>Native</h1>
+      <h3 style={sharedHeadStyle}>Native</h3>
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" />
       <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" maxLength={20} />
-      <h1>Count</h1>
-      <h4>Only Max</h4>
+      <h3 style={sharedHeadStyle}>Count</h3>
+      <h4 style={sharedHeadStyle}>Only Max</h4>
       <Input
         placeholder="count.max"
         prefixCls="rc-input"
@@ -27,7 +32,7 @@ const Demo: FC = () => {
           max: 5,
         }}
       />
-      <h4>Customize strategy</h4>
+      <h4 style={sharedHeadStyle}>Customize strategy</h4>
       <Input
         placeholder="Emoji count 1"
         prefixCls="rc-input"
@@ -39,7 +44,7 @@ const Demo: FC = () => {
             [...new (Intl as any).Segmenter().segment(val)].length,
         }}
       />
-      <h4>Customize exceedFormatter</h4>
+      <h4 style={sharedHeadStyle}>Customize exceedFormatter</h4>
       <Input
         placeholder="Emoji count 1"
         prefixCls="rc-input"

--- a/docs/examples/show-count.tsx
+++ b/docs/examples/show-count.tsx
@@ -1,10 +1,22 @@
+import Input from 'rc-input';
 import type { FC } from 'react';
 import React from 'react';
 import '../../assets/index.less';
-import Input from 'rc-input';
 
 const Demo: FC = () => {
-  return <Input prefixCls="rc-input" showCount />;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        alignItems: 'start',
+      }}
+    >
+      <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" />
+      <Input prefixCls="rc-input" showCount defaultValue="👨‍👩‍👧‍👦" maxLength={20} />
+    </div>
+  );
 };
 
 export default Demo;

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "prettier": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "pretty-quick": "pretty-quick",
     "lint-staged": "lint-staged",
-    "test": "umi-test test",
-    "coverage": "father test --coverage",
+    "test": "rc-test",
+    "coverage": "rc-test --coverage",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -69,10 +69,10 @@
     "np": "^7.0.0",
     "prettier": "^2.0.5",
     "pretty-quick": "^3.0.0",
+    "rc-test": "^7.0.15",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "typescript": "^4.0.5",
-    "umi-test": "^1.9.7"
+    "typescript": "^4.0.5"
   },
   "peerDependencies": {
     "react": ">=16.0.0",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from 'react';
 import BaseInput from './BaseInput';
+import useCount from './hooks/useCount';
 import type { InputProps, InputRef } from './interface';
 import type { InputFocusOptions } from './utils/commonUtils';
 import {
@@ -32,6 +33,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     maxLength,
     suffix,
     showCount,
+    count,
     type = 'text',
     classes,
     classNames,
@@ -52,6 +54,10 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     }
   };
 
+  // ====================== Count =======================
+  const countConfig = useCount(count, showCount);
+
+  // ======================= Ref ========================
   useImperativeHandle(ref, () => ({
     focus,
     blur: () => {
@@ -126,6 +132,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         // specify either the value prop, or the defaultValue prop, but not both.
         'defaultValue',
         'showCount',
+        'count',
         'classes',
         'htmlSize',
         'styles',
@@ -159,17 +166,16 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     // Max length value
     const hasMaxLength = Number(maxLength) > 0;
 
-    if (suffix || showCount) {
+    if (suffix || countConfig.show) {
       const val = fixControlledValue(value);
-      const valueLength = val.length;
-      const dataCount =
-        typeof showCount === 'object'
-          ? showCount.formatter({ value: val, count: valueLength, maxLength })
-          : `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+      const valueLength = countConfig.strategy(val);
+      const dataCount = countConfig.formatter
+        ? countConfig.formatter({ value: val, count: valueLength, maxLength })
+        : `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
 
       return (
         <>
-          {!!showCount && (
+          {countConfig.show && (
             <span
               className={clsx(
                 `${prefixCls}-show-count-suffix`,
@@ -192,6 +198,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     return null;
   };
 
+  // ====================== Render ======================
   return (
     <BaseInput
       {...rest}

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -161,7 +161,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
     if (suffix || showCount) {
       const val = fixControlledValue(value);
-      const valueLength = [...val].length;
+      const valueLength = val.length;
       const dataCount =
         typeof showCount === 'object'
           ? showCount.formatter({ value: val, count: valueLength, maxLength })

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -12,11 +12,7 @@ import BaseInput from './BaseInput';
 import useCount from './hooks/useCount';
 import type { InputProps, InputRef } from './interface';
 import type { InputFocusOptions } from './utils/commonUtils';
-import {
-  fixControlledValue,
-  resolveOnChange,
-  triggerFocus,
-} from './utils/commonUtils';
+import { resolveOnChange, triggerFocus } from './utils/commonUtils';
 
 const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const {
@@ -41,10 +37,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     ...rest
   } = props;
 
-  const [value, setValue] = useMergedState(props.defaultValue, {
-    value: props.value,
-  });
   const [focused, setFocused] = useState<boolean>(false);
+  const compositionRef = React.useRef(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -54,8 +48,19 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     }
   };
 
+  // ====================== Value =======================
+  const [value, setValue] = useMergedState(props.defaultValue, {
+    value: props.value,
+  });
+  const formatValue =
+    value === undefined || value === null ? '' : String(value);
+
   // ====================== Count =======================
   const countConfig = useCount(count, showCount);
+  const mergedMax = countConfig.max || maxLength;
+  const valueLength = countConfig.strategy(formatValue);
+
+  const isOutOfRange = !!mergedMax && valueLength > mergedMax;
 
   // ======================= Ref ========================
   useImperativeHandle(ref, () => ({
@@ -80,13 +85,38 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     setFocused((prev) => (prev && disabled ? false : prev));
   }, [disabled]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (props.value === undefined) {
-      setValue(e.target.value);
+  const triggerChange = (
+    e:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.CompositionEvent<HTMLInputElement>,
+    currentValue: string,
+  ) => {
+    let cutValue = currentValue;
+
+    if (
+      !compositionRef.current &&
+      countConfig.exceedFormatter &&
+      countConfig.max &&
+      countConfig.strategy(currentValue) > countConfig.max
+    ) {
+      cutValue = countConfig.exceedFormatter(currentValue, {
+        max: countConfig.max,
+      });
     }
+    setValue(cutValue);
+
     if (inputRef.current) {
-      resolveOnChange(inputRef.current, e, onChange);
+      resolveOnChange(inputRef.current, e, onChange, cutValue);
     }
+  };
+
+  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    triggerChange(e, e.target.value);
+  };
+
+  const onCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    compositionRef.current = false;
+    triggerChange(e, e.currentTarget.value);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -143,7 +173,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       <input
         autoComplete={autoComplete}
         {...otherProps}
-        onChange={handleChange}
+        onChange={onInternalChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
@@ -151,6 +181,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
           prefixCls,
           {
             [`${prefixCls}-disabled`]: disabled,
+            [`${prefixCls}-out-of-range`]: isOutOfRange,
           },
           classNames?.input,
         )}
@@ -158,20 +189,26 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         ref={inputRef}
         size={htmlSize}
         type={type}
+        onCompositionStart={() => {
+          compositionRef.current = true;
+        }}
+        onCompositionEnd={onCompositionEnd}
       />
     );
   };
 
   const getSuffix = () => {
     // Max length value
-    const hasMaxLength = Number(maxLength) > 0;
+    const hasMaxLength = Number(mergedMax) > 0;
 
     if (suffix || countConfig.show) {
-      const val = fixControlledValue(value);
-      const valueLength = countConfig.strategy(val);
-      const dataCount = countConfig.formatter
-        ? countConfig.formatter({ value: val, count: valueLength, maxLength })
-        : `${valueLength}${hasMaxLength ? ` / ${maxLength}` : ''}`;
+      const dataCount = countConfig.showFormatter
+        ? countConfig.showFormatter({
+            value: formatValue,
+            count: valueLength,
+            maxLength: mergedMax,
+          })
+        : `${valueLength}${hasMaxLength ? ` / ${mergedMax}` : ''}`;
 
       return (
         <>
@@ -206,7 +243,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       className={className}
       inputElement={getInputElement()}
       handleReset={handleReset}
-      value={fixControlledValue(value)}
+      value={formatValue}
       focused={focused}
       triggerFocus={focus}
       suffix={getSuffix()}

--- a/src/hooks/useCount.ts
+++ b/src/hooks/useCount.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import type { InputProps } from '..';
+
+export default function useCount(
+  count?: InputProps['count'],
+  showCount?: InputProps['showCount'],
+) {
+  return React.useMemo(() => {
+    let countConfig = count || {};
+
+    if (!count && showCount) {
+      countConfig = {
+        show: true,
+        formatter: typeof showCount === 'function' ? showCount : undefined,
+      };
+    }
+
+    return {
+      ...countConfig,
+      strategy: countConfig.strategy || ((value) => value.length),
+    };
+  }, [count, showCount]);
+}

--- a/src/hooks/useCount.ts
+++ b/src/hooks/useCount.ts
@@ -2,11 +2,6 @@ import * as React from 'react';
 import type { InputProps } from '..';
 import type { CountConfig, ShowCountFormatter } from '../interface';
 
-function isEmoji(character: string) {
-  const codePoint = character.codePointAt(0)!;
-  return codePoint >= 0x1f300 && codePoint <= 0x1f6ff;
-}
-
 type ForcedCountConfig = Omit<CountConfig, 'show'> &
   Pick<Required<CountConfig>, 'strategy'> & {
     show: boolean;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -60,13 +60,11 @@ export interface BaseInputProps extends CommonInputProps {
   };
 }
 
-export interface ShowCountProps {
-  formatter: (args: {
-    value: string;
-    count: number;
-    maxLength?: number;
-  }) => ReactNode;
-}
+export type ShowCountFormatter = (args: {
+  value: string;
+  count: number;
+  maxLength?: number;
+}) => ReactNode;
 
 export interface InputProps
   extends CommonInputProps,
@@ -103,7 +101,12 @@ export interface InputProps
     string
   >;
   onPressEnter?: KeyboardEventHandler<HTMLInputElement>;
-  showCount?: boolean | ShowCountProps;
+  /** @deprecated Use `count` instead */
+  showCount?:
+    | boolean
+    | {
+        formatter: ShowCountFormatter;
+      };
   autoComplete?: string;
   htmlSize?: number;
   classNames?: CommonInputProps['classNames'] & {
@@ -113,6 +116,12 @@ export interface InputProps
   styles?: CommonInputProps['styles'] & {
     input?: CSSProperties;
     count?: CSSProperties;
+  };
+  count?: {
+    max?: number;
+    strategy?: (value: string) => number;
+    show?: boolean;
+    formatter?: ShowCountFormatter;
   };
 }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -66,6 +66,19 @@ export type ShowCountFormatter = (args: {
   maxLength?: number;
 }) => ReactNode;
 
+export type ExceedFormatter = (
+  value: string,
+  config: { max: number },
+) => string;
+
+export interface CountConfig {
+  max?: number;
+  strategy?: (value: string) => number;
+  show?: boolean | ShowCountFormatter;
+  /** Trigger when content larger than the `max` limitation */
+  exceedFormatter?: ExceedFormatter;
+}
+
 export interface InputProps
   extends CommonInputProps,
     Omit<
@@ -117,12 +130,7 @@ export interface InputProps
     input?: CSSProperties;
     count?: CSSProperties;
   };
-  count?: {
-    max?: number;
-    strategy?: (value: string) => number;
-    show?: boolean;
-    formatter?: ShowCountFormatter;
-  };
+  count?: CountConfig;
 }
 
 export interface InputRef {

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -1,5 +1,5 @@
-import type { BaseInputProps, InputProps } from '../interface';
 import type React from 'react';
+import type { BaseInputProps, InputProps } from '../interface';
 
 export function hasAddon(props: BaseInputProps | InputProps) {
   return !!(props.addonBefore || props.addonAfter);
@@ -95,11 +95,4 @@ export function triggerFocus(
         element.setSelectionRange(0, len);
     }
   }
-}
-
-export function fixControlledValue<T>(value: T) {
-  if (typeof value === 'undefined' || value === null) {
-    return '';
-  }
-  return String(value);
 }

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`Input allowClear should change type when click 1`] = `
 exports[`Input allowClear should change type when click 2`] = `
 <div>
   <span
-    class="rc-input-affix-wrapper"
+    class="rc-input-affix-wrapper rc-input-affix-wrapper-focused"
   >
     <input
       class="rc-input"

--- a/tests/count.test.tsx
+++ b/tests/count.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import Input from '../src';
 
@@ -24,5 +24,57 @@ describe('Input.Count', () => {
     expect(
       container.querySelector('.rc-input-show-count-suffix')?.textContent,
     ).toEqual('1');
+  });
+
+  it('exceed style', () => {
+    const { container } = render(
+      <Input count={{ show: true, max: 5 }} value="👨‍👩‍👧‍👦" />,
+    );
+    expect(container.querySelector('.rc-input-out-of-range')).toBeTruthy();
+  });
+
+  it('show formatter', () => {
+    const { container } = render(
+      <Input
+        count={{
+          show: ({ value, count, maxLength }) =>
+            `${value}_${count}_${maxLength}`,
+        }}
+        value="👨‍👩‍👧‍👦"
+        maxLength={5}
+      />,
+    );
+    expect(
+      container.querySelector('.rc-input-show-count-suffix')?.textContent,
+    ).toEqual('👨‍👩‍👧‍👦_11_5');
+  });
+
+  it('exceedFormatter', () => {
+    const { container } = render(
+      <Input
+        count={{
+          show: true,
+          max: 3,
+          exceedFormatter: (val, { max }) =>
+            getSegments(val)
+              .filter((seg) => seg.index + seg.segment.length <= max)
+              .map((seg) => seg.segment)
+              .join(''),
+        }}
+      />,
+    );
+
+    // Allow input
+    fireEvent.compositionStart(container.querySelector('input')!);
+    fireEvent.change(container.querySelector('input')!, {
+      target: {
+        value: '🔥🔥🔥🔥🔥',
+      },
+    });
+    expect(container.querySelector('input')?.value).toEqual('🔥🔥🔥🔥🔥');
+
+    // Fallback
+    fireEvent.compositionEnd(container.querySelector('input')!);
+    expect(container.querySelector('input')?.value).toEqual('🔥');
   });
 });

--- a/tests/count.test.tsx
+++ b/tests/count.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import Input from '../src';
+
+const getSegments = (val: string) => [
+  ...new (Intl as any).Segmenter().segment(val),
+];
+
+describe('Input.Count', () => {
+  it('basic emoji take length', () => {
+    const { container } = render(<Input count={{ show: true }} value="👨‍👩‍👧‍👦" />);
+    expect(
+      container.querySelector('.rc-input-show-count-suffix')?.textContent,
+    ).toEqual('11');
+  });
+
+  it('strategy', () => {
+    const { container } = render(
+      <Input
+        count={{ show: true, strategy: (val) => getSegments(val).length }}
+        value="👨‍👩‍👧‍👦"
+      />,
+    );
+    expect(
+      container.querySelector('.rc-input-show-count-suffix')?.textContent,
+    ).toEqual('1');
+  });
+});

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -102,35 +102,6 @@ describe('should support showCount', () => {
     ).toBe('8 / 5');
   });
 
-  describe('emoji', () => {
-    it('should minimize value between emoji length and maxLength', () => {
-      const { container } = render(
-        <Input prefixCls="rc-input" maxLength={1} showCount value="👀" />,
-      );
-      expect(container.querySelector('input')?.value).toBe('👀');
-      expect(
-        container.querySelector('.rc-input-show-count-suffix')?.innerHTML,
-      ).toBe('1 / 1');
-
-      const { container: container1 } = render(
-        <Input prefixCls="rc-input" maxLength={2} showCount value="👀" />,
-      );
-      expect(
-        container1.querySelector('.rc-input-show-count-suffix')?.innerHTML,
-      ).toBe('1 / 2');
-    });
-
-    it('slice emoji', () => {
-      const { container } = render(
-        <Input prefixCls="rc-input" maxLength={5} showCount value="1234😂" />,
-      );
-      expect(container.querySelector('input')?.value).toBe('1234😂');
-      expect(
-        container.querySelector('.rc-input-show-count-suffix')?.innerHTML,
-      ).toBe('5 / 5');
-    });
-  });
-
   it('count formatter', () => {
     const { container } = render(
       <Input

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
       "rc-input": ["src/index.tsx"]
     }
   },
-  "include": [".dumi/**/*", ".dumirc.ts", "**/*.ts", "**/*.tsx"]
+  "include": [".dumirc.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/37733

贴一下之前同步会讨论的结论：
* 对于 Input 和 TextArea 将 `showCount` 的计算逻辑还原给原生的计算逻辑。让 `count` 和 `maxLength` 保持同步。
* 对于有需要定制化计算逻辑的场景（普遍是中文 or emoji 场景），提供定制接口允许开发者自行定义。

该 PR：
* 继上述结论，提取 `count` 接口：
```tsx
interface CountConfig {
  // 代理 `max` 逻辑，当开发者没有提供裁剪逻辑时参考 InputNumber 提供错误样式。
  max?: number;
  // 计数策略，不提供时以原生 `string.length` 处理。反之可定制自己的逻辑，如 emoji 始终占据一个长度。
  strategy?: (value: string) => number;
  // 同 `showCount`，不再复述
  show?: boolean | ShowCountFormatter;
  // 当超出 `max` 范围时处理逻辑，允许开发者额外定制裁剪逻辑。该方法会略过 `composition` 事件以防止被输入法卡住的情况。
  exceedFormatter?: ExceedFormatter;
}
```


<img width="226" alt="截屏2023-09-27 14 27 15" src="https://github.com/react-component/input/assets/5378891/110a7236-58ea-4b3e-b35a-ff2de41d5ae1">

#### exceedFormatter

![Kapture 2023-09-27 at 14 29 28](https://github.com/react-component/input/assets/5378891/37f770a7-2734-45c4-85ee-8431e527ec93)
