### PR TITLE
refactor: BaseInput

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -267,7 +267,6 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       {...rest}
       prefixCls={prefixCls}
       className={clsx(className, outOfRangeCls)}
-      inputElement={getInputElement()}
       handleReset={handleReset}
       value={formatValue}
       focused={focused}
@@ -277,7 +276,9 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       classes={classes}
       classNames={classNames}
       styles={styles}
-    />
+    >
+      {getInputElement()}
+    </BaseInput>
   );
 });
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,6 +24,8 @@ export interface CommonInputProps {
     affixWrapper?: string;
     prefix?: string;
     suffix?: string;
+    groupWrapper?: string;
+    wrapper?: string;
   };
   styles?: {
     affixWrapper?: CSSProperties;
@@ -39,7 +41,8 @@ export type ValueType = InputHTMLAttributes<HTMLInputElement>['value'] | bigint;
 
 export interface BaseInputProps extends CommonInputProps {
   value?: ValueType;
-  inputElement: ReactElement;
+  /** @deprecated Use `children` instead */
+  inputElement?: ReactElement;
   prefixCls?: string;
   className?: string;
   style?: CSSProperties;
@@ -58,6 +61,7 @@ export interface BaseInputProps extends CommonInputProps {
     wrapper?: 'span' | 'div';
     groupAddon?: 'span' | 'div';
   };
+  children: ReactElement;
 }
 
 export type ShowCountFormatter = (args: {

--- a/tests/BaseInput.test.tsx
+++ b/tests/BaseInput.test.tsx
@@ -6,7 +6,9 @@ import BaseInput from '../src/BaseInput';
 describe('BaseInput', () => {
   it('should render perfectly', () => {
     const { container } = render(
-      <BaseInput prefixCls="rc-input" inputElement={<input />} />,
+      <BaseInput prefixCls="rc-input">
+        <input />
+      </BaseInput>,
     );
     expect(container).toMatchSnapshot();
   });
@@ -14,18 +16,14 @@ describe('BaseInput', () => {
   it('prefix and suffix should render properly', () => {
     const { container } = render(
       <div>
-        <BaseInput
-          prefixCls="rc-input"
-          inputElement={<input />}
-          prefix="prefix"
-        />
+        <BaseInput prefixCls="rc-input" prefix="prefix">
+          <input />
+        </BaseInput>
         <br />
         <br />
-        <BaseInput
-          prefixCls="rc-input"
-          inputElement={<input />}
-          suffix="suffix"
-        />
+        <BaseInput prefixCls="rc-input" suffix="suffix">
+          <input />
+        </BaseInput>
       </div>,
     );
     expect(container).toMatchSnapshot();
@@ -34,18 +32,14 @@ describe('BaseInput', () => {
   it('addon should render properly', () => {
     const { container } = render(
       <div>
-        <BaseInput
-          prefixCls="rc-input"
-          inputElement={<input />}
-          addonBefore="addonBefore"
-        />
+        <BaseInput prefixCls="rc-input" addonBefore="addonBefore">
+          <input />
+        </BaseInput>
         <br />
         <br />
-        <BaseInput
-          prefixCls="rc-input"
-          inputElement={<input />}
-          addonAfter="addonAfter"
-        />
+        <BaseInput prefixCls="rc-input" addonAfter="addonAfter">
+          <input />
+        </BaseInput>
       </div>,
     );
     expect(container).toMatchSnapshot();
@@ -72,12 +66,11 @@ describe('BaseInput', () => {
         <BaseInput
           prefixCls="rc-input"
           allowClear={{ clearIcon: '✖' }}
-          inputElement={
-            <input onChange={handleChange} onBlur={onBlur} onFocus={onFocus} />
-          }
           value={value}
           handleReset={handleReset}
-        />
+        >
+          <input onChange={handleChange} onBlur={onBlur} onFocus={onFocus} />
+        </BaseInput>
       );
     };
 
@@ -102,16 +95,16 @@ describe('BaseInput', () => {
 
   it('should display clearIcon correctly', () => {
     const { container, rerender } = render(
-      <BaseInput prefixCls="rc-input" inputElement={<input />} allowClear />,
+      <BaseInput prefixCls="rc-input" allowClear>
+        <input />
+      </BaseInput>,
     );
     const clearIcon = container.querySelector('.rc-input-clear-icon');
     expect(clearIcon?.innerHTML).toBe('✖');
     rerender(
-      <BaseInput
-        prefixCls="rc-input"
-        inputElement={<input />}
-        allowClear={{ clearIcon: 'clear' }}
-      />,
+      <BaseInput prefixCls="rc-input" allowClear={{ clearIcon: 'clear' }}>
+        <input />
+      </BaseInput>,
     );
     expect(clearIcon?.innerHTML).toBe('clear');
   });
@@ -121,10 +114,11 @@ describe('BaseInput', () => {
     const { container } = render(
       <BaseInput
         prefixCls="rc-input"
-        inputElement={<input ref={inputRef} />}
         triggerFocus={() => inputRef.current?.focus()}
         prefix="$"
-      />,
+      >
+        <input ref={inputRef} />
+      </BaseInput>,
     );
     fireEvent.click(container.querySelector('.rc-input-affix-wrapper')!);
     expect(document.activeElement).toBe(container.querySelector('input'));
@@ -140,8 +134,9 @@ describe('BaseInput', () => {
             'data-test': 'test',
           },
         }}
-        inputElement={<input />}
-      />,
+      >
+        <input />
+      </BaseInput>,
     );
     expect(
       container
@@ -152,11 +147,9 @@ describe('BaseInput', () => {
 
   it('should apply className to inputElement', () => {
     const { container } = render(
-      <BaseInput
-        prefixCls="rc-input"
-        className="test-base"
-        inputElement={<input className="test" />}
-      />,
+      <BaseInput prefixCls="rc-input" className="test-base">
+        <input className="test" />
+      </BaseInput>,
     );
     expect(container.querySelector('.test-base')).toBeTruthy();
     expect(container.querySelector('.test')).toBeTruthy();
@@ -164,12 +157,9 @@ describe('BaseInput', () => {
 
   it('should not pass className to inputElement when has addon', () => {
     const { container } = render(
-      <BaseInput
-        prefixCls="rc-input"
-        className="test-base"
-        addonBefore="addon"
-        inputElement={<input className="test" />}
-      />,
+      <BaseInput prefixCls="rc-input" className="test-base" addonBefore="addon">
+        <input className="test" />
+      </BaseInput>,
     );
     expect(
       container.querySelector('input')?.classList.contains('test'),
@@ -181,12 +171,9 @@ describe('BaseInput', () => {
 
   it('should correct render with prefix and addon', () => {
     const { container } = render(
-      <BaseInput
-        prefixCls="rc-input"
-        prefix="prefix"
-        addonBefore="addon"
-        inputElement={<input />}
-      />,
+      <BaseInput prefixCls="rc-input" prefix="prefix" addonBefore="addon">
+        <input />
+      </BaseInput>,
     );
     expect(container).toMatchSnapshot();
   });
@@ -197,14 +184,15 @@ describe('BaseInput', () => {
         prefixCls="rc-input"
         prefix="prefix"
         addonBefore="addon"
-        inputElement={<input />}
         components={{
           affixWrapper: 'div',
           groupWrapper: 'div',
           wrapper: 'div',
           groupAddon: 'div',
         }}
-      />,
+      >
+        <input />
+      </BaseInput>,
     );
     expect(container).toMatchSnapshot();
   });
@@ -215,7 +203,6 @@ describe('BaseInput', () => {
         prefixCls="rc-input"
         prefix="prefix"
         addonBefore="addon"
-        inputElement={<input />}
         styles={{
           affixWrapper: {
             color: 'red',
@@ -224,7 +211,9 @@ describe('BaseInput', () => {
             color: 'blue',
           },
         }}
-      />,
+      >
+        <input />
+      </BaseInput>,
     );
 
     expect(


### PR DESCRIPTION
- 完全废弃 `classes`，所有属性移到 `classNames` 下
- 废弃 `inputElement`，使用 `children` 代替
- `className` `style` 和 `hidden` 属性现在会在最后附加到返回的元素上，移除复杂的判断逻辑
- 一些 BaseInput 的结构优化