### PR TITLE
fix: trigger onChange twice when inputting using the input method

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -141,8 +141,9 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     e: React.CompositionEvent<HTMLInputElement>,
   ) => {
     compositionRef.current = false;
-    if (isExceed(e.currentTarget.value))
+    if (isExceed(e.currentTarget.value)) {
       triggerChange(e, e.currentTarget.value);
+    }
     onCompositionEnd?.(e);
   };
 

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -68,6 +68,14 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const valueLength = countConfig.strategy(formatValue);
 
   const isOutOfRange = !!mergedMax && valueLength > mergedMax;
+  const isExceed = (currentValue: string) => {
+    return (
+      !compositionRef.current &&
+      countConfig.exceedFormatter &&
+      countConfig.max &&
+      countConfig.strategy(currentValue) > countConfig.max
+    );
+  };
 
   // ======================= Ref ========================
   useImperativeHandle(ref, () => ({
@@ -100,14 +108,9 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   ) => {
     let cutValue = currentValue;
 
-    if (
-      !compositionRef.current &&
-      countConfig.exceedFormatter &&
-      countConfig.max &&
-      countConfig.strategy(currentValue) > countConfig.max
-    ) {
-      cutValue = countConfig.exceedFormatter(currentValue, {
-        max: countConfig.max,
+    if (isExceed(currentValue)) {
+      cutValue = countConfig.exceedFormatter!(currentValue, {
+        max: countConfig.max!,
       });
 
       if (currentValue !== cutValue) {
@@ -138,7 +141,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     e: React.CompositionEvent<HTMLInputElement>,
   ) => {
     compositionRef.current = false;
-    triggerChange(e, e.currentTarget.value);
+    if (isExceed(e.currentTarget.value))
+      triggerChange(e, e.currentTarget.value);
     onCompositionEnd?.(e);
   };
 

--- a/tests/count.test.tsx
+++ b/tests/count.test.tsx
@@ -109,6 +109,45 @@ describe('Input.Count', () => {
     expect(setSelectionRange).toHaveBeenCalledWith(2, 2);
   });
 
+  it('input using the input method should trigger onChange once', () => {
+    const onChange = jest.fn();
+    const { container } = render(<Input onChange={onChange} />);
+    const input = container.querySelector('input')!;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionUpdate(input, { data: '你' });
+    fireEvent.compositionEnd(input, { data: '你好' });
+    fireEvent.input(input, { target: { value: '你好' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('using the input method to enter the cropped content should trigger onChange twice', () => {
+    const onChange = jest.fn();
+    const onCompositionEnd = jest.fn();
+    const { container } = render(
+      <Input
+        count={{
+          show: true,
+          max: 3,
+          exceedFormatter: (val, { max }) =>
+            getSegments(val)
+              .filter((seg) => seg.index + seg.segment.length <= max)
+              .map((seg) => seg.segment)
+              .join(''),
+        }}
+        onChange={onChange}
+        onCompositionEnd={onCompositionEnd}
+      />,
+    );
+    const input = container.querySelector('input')!;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionUpdate(input, { target: { value: '你' } });
+    fireEvent.compositionUpdate(input, { target: { value: '你好' } });
+    fireEvent.compositionUpdate(input, { target: { value: '你好世' } });
+    fireEvent.compositionUpdate(input, { target: { value: '你好世界' } });
+    fireEvent.compositionEnd(input, { target: { value: '你好世界' } });
+    expect(input?.value).toEqual('你好世');
+  });
+
   describe('cls', () => {
     it('raw', () => {
       const { container } = render(


### PR DESCRIPTION
The onCompositionEnd event will be called when the user input method combination ends, triggering an onChange event, but it only needs to be called after the count method of Input is successfully cropped.

fix https://github.com/ant-design/ant-design/issues/46587
close #61