### PR TITLE
chore: export internal type and func for reuse

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,10 @@
 import BaseInput from './BaseInput';
 import Input from './Input';
-
-export { BaseInput };
+import { triggerFocus, type InputFocusOptions } from './utils/commonUtils';
 
 export type { InputProps, InputRef } from './interface';
+export type { InputFocusOptions };
+export { BaseInput };
+export { triggerFocus };
 
 export default Input;


### PR DESCRIPTION
antd中重复定义了type InputFocusOptions，以及function triggerFocus，但其实rcInput中已经提供了，完全可以复用

![QQ_1730281856781](https://github.com/user-attachments/assets/059ced43-1b2e-48fe-8f74-cb4486749fd1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了 `InputFocusOptions` 类型，以增强输入组件的功能。
	- 引入了 `triggerFocus` 方法，改善用户输入体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->