### PR TITLE
fix: clear button should have type="button"

### DIFF
--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -81,6 +81,7 @@ const BaseInput = React.forwardRef<HolderRef, BaseInputProps>((props, ref) => {
 
       clearIcon = (
         <button
+          type="button"
           onClick={(event) => {
             handleReset?.(event);
             onClear?.();

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`Input allowClear should change type when click 1`] = `
     >
       <button
         class="rc-input-clear-icon"
+        type="button"
       >
         ✖
       </button>
@@ -140,6 +141,7 @@ exports[`Input allowClear should change type when click 2`] = `
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
+        type="button"
       >
         ✖
       </button>
@@ -163,6 +165,7 @@ exports[`Input allowClear should not show icon if defaultValue is undefined or e
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
+        type="button"
       >
         ✖
       </button>
@@ -186,6 +189,7 @@ exports[`Input allowClear should not show icon if defaultValue is undefined or e
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
+        type="button"
       >
         ✖
       </button>
@@ -209,6 +213,7 @@ exports[`Input allowClear should not show icon if value is undefined or empty st
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
+        type="button"
       >
         ✖
       </button>
@@ -232,6 +237,7 @@ exports[`Input allowClear should not show icon if value is undefined or empty st
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
+        type="button"
       >
         ✖
       </button>


### PR DESCRIPTION
close https://github.com/react-component/input/issues/82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在清除图标的按钮元素中添加了 `type="button"` 属性，以确保点击时不会提交表单，提升了可访问性和功能性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->