### PR TITLE
fix: fix BaseInput missing ref binding

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -305,6 +305,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       classes={classes}
       classNames={classNames}
       styles={styles}
+      ref={holderRef}
     >
       {getInputElement()}
     </BaseInput>

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -454,6 +454,42 @@ describe('Input ref', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  describe('nativeElement', () => {
+    it('is input', () => {
+      const ref = React.createRef<InputRef>();
+      render(<Input ref={ref} prefixCls="rc-input" />);
+      expect(ref.current?.nativeElement).toHaveClass('rc-input');
+    });
+
+    it('is affix wrapper', () => {
+      const ref = React.createRef<InputRef>();
+      render(
+        <Input
+          ref={ref}
+          prefixCls="rc-input"
+          prefix={'prefix'}
+          suffix={'suffix'}
+        />,
+      );
+      expect(ref.current?.nativeElement).toHaveClass('rc-input-affix-wrapper');
+    });
+
+    it('is group wrapper', () => {
+      const ref = React.createRef<InputRef>();
+      render(
+        <Input
+          ref={ref}
+          prefixCls="rc-input"
+          prefix={'prefix'}
+          suffix={'suffix'}
+          addonBefore={'addonBefore'}
+          addonAfter={'addonAfter'}
+        />,
+      );
+      expect(ref.current?.nativeElement).toHaveClass('rc-input-group-wrapper');
+    });
+  });
 });
 
 describe('resolveChange should work', () => {


### PR DESCRIPTION
### Summary
- 修复Popover 和 Input 搭配使用， Popver位置不对的问题 [https://github.com/ant-design/ant-design/issues/51997](url) 
- 但是对于nativeElement字段是属于破坏性更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了 `Input` 组件的引用能力，允许外部组件访问原生输入元素。

- **测试**
	- 为 `Input` 组件的 `nativeElement` 属性添加了新的测试用例，提高了组件测试覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->