### PR TITLE
fix: LiteralUnion type is not work

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,3 @@
 /** https://github.com/Microsoft/TypeScript/issues/29729 */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type LiteralUnion<T extends U, U> = T | (U & {});
+export type LiteralUnion<T extends U, U> = T | (U & Record<never, never>);


### PR DESCRIPTION
LiteralUnion 的类型现在无法正常提示了，antd 的 Input 同理

之前
![image](https://github.com/user-attachments/assets/db5a5695-4cc2-4e74-9402-bd59b6ea5d0d)

现在
![image](https://github.com/user-attachments/assets/2216d725-aedb-4f93-b5b2-32ce0a64acc0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了类型定义，提升了类型推断和兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->