### PR TITLE
docs: remove stale Input.TextArea references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,47 +40,47 @@ render(<Input placeholder="input" allowClear />, mountNode);
 ```
 
 ```js
-import Input from '@rc-component/input';
+import { TextArea } from '@rc-component/input';
 import { render } from 'react-dom';
 
-render(<Input.TextArea autoSize showCount />, mountNode);
+render(<TextArea autoSize showCount />, mountNode);
 ```
 
 ## API
 
-| Property              | Type                                                                                              | Default  | Description                                                                                                                                                         |
-| --------------------- | ------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| prefixCls             | string                                                                                            | rc-input |                                                                                                                                                                     |
-| className             | string                                                                                            | ''       | additional class name of input                                                                                                                                      |
-| style                 | React.CSSProperties                                                                               |          | style properties of input                                                                                                                                           |
-| affixWrapperClassName | string                                                                                            | -        | className with '@rc-component/input-affix-wrapper'                                                                                                                  |
-| groupClassName        | string                                                                                            | -        | className with '@rc-component/input-group-wrapper'                                                                                                                  |
-| wrapperClassName      | string                                                                                            | -        | className with '@rc-component/input-wrapper'                                                                                                                        |
-| addonAfter            | ReactNode                                                                                         | -        | The label text displayed after (on the right side of) the input field                                                                                               |
-| addonBefore           | ReactNode                                                                                         | -        | The label text displayed before (on the left side of) the input field                                                                                               |
-| allowClear            | boolean &#124; { clearIcon: ReactNode }                                                           | false    | If allow to remove input content with clear icon                                                                                                                    |
-| bordered              | boolean                                                                                           | true     | Whether has border style                                                                                                                                            |
-| defaultValue          | string                                                                                            | -        | The initial input content                                                                                                                                           |
-| disabled              | boolean                                                                                           | false    | Whether the input is disabled                                                                                                                                       |
-| id                    | string                                                                                            | -        | The ID for input                                                                                                                                                    |
-| maxLength             | number                                                                                            | -        | The max length                                                                                                                                                      |
-| showCount             | boolean &#124; { formatter: ({ value: string, count: number, maxLength?: number }) => ReactNode } | false    | Whether show text count                                                                                                                                             |
-| prefix                | ReactNode                                                                                         | -        | The prefix icon for the Input                                                                                                                                       |
-| suffix                | ReactNode                                                                                         | -        | The suffix icon for the Input                                                                                                                                       |
-| type                  | string                                                                                            | `text`   | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)( use `Input.TextArea` instead of `type="textarea"`) |
-| value                 | string                                                                                            | -        | The input content value                                                                                                                                             |
-| onChange              | function(e)                                                                                       | -        | Callback when user input                                                                                                                                            |
-| onPressEnter          | function(e)                                                                                       | -        | The callback function that is triggered when Enter key is pressed                                                                                                   |
+| Property              | Type                                                                                              | Default  | Description                                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| prefixCls             | string                                                                                            | rc-input |                                                                                                                                                                                |
+| className             | string                                                                                            | ''       | additional class name of input                                                                                                                                                 |
+| style                 | React.CSSProperties                                                                               |          | style properties of input                                                                                                                                                      |
+| affixWrapperClassName | string                                                                                            | -        | className with '@rc-component/input-affix-wrapper'                                                                                                                             |
+| groupClassName        | string                                                                                            | -        | className with '@rc-component/input-group-wrapper'                                                                                                                             |
+| wrapperClassName      | string                                                                                            | -        | className with '@rc-component/input-wrapper'                                                                                                                                   |
+| addonAfter            | ReactNode                                                                                         | -        | The label text displayed after (on the right side of) the input field                                                                                                          |
+| addonBefore           | ReactNode                                                                                         | -        | The label text displayed before (on the left side of) the input field                                                                                                          |
+| allowClear            | boolean &#124; { clearIcon: ReactNode }                                                           | false    | If allow to remove input content with clear icon                                                                                                                               |
+| bordered              | boolean                                                                                           | true     | Whether has border style                                                                                                                                                       |
+| defaultValue          | string                                                                                            | -        | The initial input content                                                                                                                                                      |
+| disabled              | boolean                                                                                           | false    | Whether the input is disabled                                                                                                                                                  |
+| id                    | string                                                                                            | -        | The ID for input                                                                                                                                                               |
+| maxLength             | number                                                                                            | -        | The max length                                                                                                                                                                 |
+| showCount             | boolean &#124; { formatter: ({ value: string, count: number, maxLength?: number }) => ReactNode } | false    | Whether show text count                                                                                                                                                        |
+| prefix                | ReactNode                                                                                         | -        | The prefix icon for the Input                                                                                                                                                  |
+| suffix                | ReactNode                                                                                         | -        | The suffix icon for the Input                                                                                                                                                  |
+| type                  | string                                                                                            | `text`   | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types) (use the named `TextArea` export instead of `type="textarea"`) |
+| value                 | string                                                                                            | -        | The input content value                                                                                                                                                        |
+| onChange              | function(e)                                                                                       | -        | Callback when user input                                                                                                                                                       |
+| onPressEnter          | function(e)                                                                                       | -        | The callback function that is triggered when Enter key is pressed                                                                                                              |
 
 ## TextArea
 
-`rc-textarea` has been migrated into `@rc-component/input`. Use `Input.TextArea` or the named `TextArea` export for all textarea-related features.
+`rc-textarea` has been migrated into `@rc-component/input`. Use the named `TextArea` export for all textarea-related features.
 
 ```js
-import Input, { TextArea } from '@rc-component/input';
+import { TextArea } from '@rc-component/input';
 
-<Input.TextArea allowClear autoSize />;
 <TextArea showCount maxLength={100} />;
+<TextArea allowClear autoSize />;
 ```
 
 | Property     | Type                        | Default     | Description                                                                                    |
@@ -126,7 +126,7 @@ useEffect(() => {
   console.log(textareaRef.current.resizableTextArea);
 }, []);
 
-<Input.TextArea ref={textareaRef} />;
+<TextArea ref={textareaRef} />;
 ```
 
 | Property          | Type                   | Description                              |


### PR DESCRIPTION
统一清理了 `rc-input` 中残留的 `Input.TextArea` 相关描述和示例，改为当前实际支持的命名导出方式：

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档
* 更新了 TextArea 组件的使用文档和导入指南
* 修改了示例代码以反映组件的最新调用方式
* 调整了 API 参考中的相关说明

<!-- end of auto-generated comment: release notes by coderabbit.ai -->