### PR TITLE
fix: remove tabIndex={-1} from clear button to make it keyboard accessible

### DIFF
--- a/src/BaseInput.tsx
+++ b/src/BaseInput.tsx
@@ -88,7 +88,6 @@ const BaseInput = React.forwardRef<HolderRef, BaseInputProps>((props, ref) => {
       clearIcon = (
         <button
           type="button"
-          tabIndex={-1}
           onClick={(event) => {
             handleReset?.(event);
             onClear?.();

--- a/tests/BaseInput.test.tsx
+++ b/tests/BaseInput.test.tsx
@@ -51,8 +51,6 @@ describe('BaseInput', () => {
     const onBlur = jest.fn();
     const onFocus = jest.fn();
 
-    const user = userEvent.setup();
-
     const Demo: FC = () => {
       const [value, setValue] = useState<string>('');
 
@@ -97,33 +95,27 @@ describe('BaseInput', () => {
       expect(inputEl!.value).toBe('');
     });
 
-    // it('By focus and Space', async () => {
-    //   const { container } = render(<Demo />);
+    it.each(['[Space]', '[Enter]'])('By focus and %s', async (key) => {
+      const user = userEvent.setup();
+      const { container } = render(<Demo />);
 
-    //   const inputEl = container.querySelector('input');
-    //   await user.click(inputEl!);
+      const inputEl = container.querySelector('input');
+      await user.click(inputEl!);
 
-    //   await user.type(inputEl!, 'some text');
-    //   expect(inputEl!.value).toBe('some text');
+      await user.type(inputEl!, 'some text');
+      expect(inputEl!.value).toBe('some text');
 
-    //   await user.tab();
-    //   await user.keyboard('[Space]');
-    //   expect(inputEl!.value).toBe('');
-    // });
+      await user.tab();
 
-    // it('By focus and Enter', async () => {
-    //   const { container } = render(<Demo />);
+      const clearIcon = container.querySelector<HTMLButtonElement>(
+        '.rc-input-clear-icon',
+      )!;
+      expect(document.activeElement).toBe(clearIcon);
+      expect(clearIcon.tabIndex).toBe(0);
 
-    //   const inputEl = container.querySelector('input');
-    //   await user.click(inputEl!);
-
-    //   await user.type(inputEl!, 'some text');
-    //   expect(inputEl!.value).toBe('some text');
-
-    //   await user.tab();
-    //   await user.keyboard('[Enter]');
-    //   expect(inputEl!.value).toBe('');
-    // });
+      await user.keyboard(key);
+      expect(inputEl!.value).toBe('');
+    });
   });
 
   it('should display clearIcon correctly', () => {

--- a/tests/__snapshots__/TextArea.allowClear.test.tsx.snap
+++ b/tests/__snapshots__/TextArea.allowClear.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -33,7 +32,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -54,7 +52,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -75,7 +72,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -96,7 +92,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -117,7 +112,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖

--- a/tests/__snapshots__/TextArea.test.tsx.snap
+++ b/tests/__snapshots__/TextArea.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`TextArea classNames and styles should work 1`] = `
       <button
         class="rc-textarea-clear-icon rc-textarea-clear-icon-has-suffix custom-clear"
         style="color: orange;"
-        tabindex="-1"
         type="button"
       >
         ✖

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`Input allowClear classNames and styles should work 1`] = `
       <button
         class="rc-input-clear-icon rc-input-clear-icon-has-suffix custom-clear"
         style="color: orange;"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -125,7 +124,6 @@ exports[`Input allowClear should change type when click 1`] = `
     >
       <button
         class="rc-input-clear-icon"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -150,7 +148,6 @@ exports[`Input allowClear should change type when click 2`] = `
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -175,7 +172,6 @@ exports[`Input allowClear should not show icon if defaultValue is undefined or e
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -200,7 +196,6 @@ exports[`Input allowClear should not show icon if defaultValue is undefined or e
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -225,7 +220,6 @@ exports[`Input allowClear should not show icon if value is undefined or empty st
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
-        tabindex="-1"
         type="button"
       >
         ✖
@@ -250,7 +244,6 @@ exports[`Input allowClear should not show icon if value is undefined or empty st
     >
       <button
         class="rc-input-clear-icon rc-input-clear-icon-hidden"
-        tabindex="-1"
         type="button"
       >
         ✖


### PR DESCRIPTION
This PR removes the `tabIndex={-1}` from the clear button in BaseInput component.

## Problem
The clear button had `tabIndex={-1}` which made it unreachable via keyboard navigation. This violates WCAG 2.1 success criteria 2.1.1 (Keyboard) and 2.1.3 (Keyboard No Exception), creating inequality for keyboard users who cannot access and operate this functionality.

## Solution
Remove the `tabIndex={-1}` attribute so the clear button becomes focusable by default. This allows keyboard users to tab to the clear button and activate it.

## Related Issue
Fixes ant-design/ant-design#57378

## Note
After this change, ant-design will need to add proper `:focus` styles for the clear button in their style file (`components/input/style/index.ts` - `genAllowClearStyle` function) to ensure the focus state is visually identifiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了输入框清除按钮的键盘无障碍行为：该按钮现已包含在标准 Tab 导航顺序中，可被键盘直接聚焦并激活以清除内容。

* **Tests**
  * 增加针对按键（空格与回车）和 Tab 导航的自动化测试，验证清除按钮的键盘可访问性与清除行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->