### PR TITLE
Avoid deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   },
   "dependencies": {
     "@rc-component/resize-observer": "^1.1.1",
-    "@rc-component/util": "^1.4.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.3",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import omit from '@rc-component/util/lib/omit';
+import { omit, triggerFocus, type InputFocusOptions } from '@rc-component/util';
 import React, {
   forwardRef,
   useEffect,
@@ -15,10 +15,6 @@ import useCountExceed from './hooks/useCountExceed';
 import useMergedValue from './hooks/useMergedValue';
 import type { ChangeEventInfo, InputProps, InputRef } from './interface';
 import { resolveOnChange } from './utils/commonUtils';
-import {
-  triggerFocus,
-  type InputFocusOptions,
-} from '@rc-component/util/lib/Dom/focus';
 
 const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const {

--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -1,8 +1,6 @@
-import ResizeObserver from '@rc-component/resize-observer';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import raf from '@rc-component/util/lib/raf';
 import { clsx } from 'clsx';
+import ResizeObserver from '@rc-component/resize-observer';
+import { raf, useControlledState, useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import type { ResizableTextAreaRef, TextAreaProps } from './interface';
 import calculateAutoSizeStyle from './calculateNodeHeight';

--- a/src/hooks/useMergedValue.ts
+++ b/src/hooks/useMergedValue.ts
@@ -1,4 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import { useControlledState } from '@rc-component/util';
 
 type MergedValue = string | number | readonly string[] | bigint | undefined;
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -7,8 +7,8 @@ import type {
   ReactNode,
   TextareaHTMLAttributes,
 } from 'react';
+import type { InputFocusOptions } from '@rc-component/util';
 import type { LiteralUnion } from './utils/types';
-import type { InputFocusOptions } from '@rc-component/util/lib/Dom/focus';
 
 export interface CommonInputProps {
   prefix?: ReactNode;

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
-import Input from '../src';
 import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { spyElementPrototypes } from '@rc-component/util';
+import Input from '../src';
 
 const getInputRef = () => {
   const ref = React.createRef<any>();

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import React, { ElementType } from 'react';
+import { spyElementPrototypes } from '@rc-component/util';
 import Input from '../src';
 import type { InputRef } from '../src/interface';
 import { resolveOnChange } from '../src/utils/commonUtils';

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,9 +1,6 @@
 // @ts-nocheck
 import { act } from '@testing-library/react';
-import {
-  _rs as onEsResize,
-  _rs as onLibResize,
-} from '@rc-component/resize-observer/lib/utils/observerUtil';
+import { _rs as onResize } from '@rc-component/resize-observer';
 
 export function triggerResize(
   target,
@@ -14,9 +11,7 @@ export function triggerResize(
 
   target.getBoundingClientRect = () => ({ width, height });
   // @ts-ignore
-  onLibResize([{ target }]);
-  // @ts-ignore
-  onEsResize([{ target }]);
+  onResize([{ target }]);
 
   target.style.height = `${height}px`;
   target.getBoundingClientRect = originGetBoundingClientRect;


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到包含根入口导出的版本，并升级 `@rc-component/father-plugin`。
- 将 `@rc-component/util` 与 `@rc-component/resize-observer` 的 `lib` 深路径导入调整为包根入口导入。
- 合并重复导入，并整理相关测试文件中的导入顺序。

## 验证

- `npm run lint` 通过，保留既有的 `react-hooks/exhaustive-deps` warning。
- `npm test -- --runInBand` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级内部依赖版本以支持最新功能和改进。

* **Refactor**
  * 优化模块导入结构，简化代码组织。

* **Tests**
  * 更新测试用例以确保功能正常运行。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/input/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->