### PR TITLE
fix: keep onChange target mounted when value does not need cloning

### DIFF
--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -45,6 +45,16 @@ function cloneEvent<
   return newEvent;
 }
 
+function cloneEventWithTarget<
+  EventType extends React.SyntheticEvent<any, any>,
+  Element extends HTMLInputElement | HTMLTextAreaElement,
+>(event: EventType, target: Element): EventType {
+  return Object.create(event, {
+    target: { value: target },
+    currentTarget: { value: target },
+  });
+}
+
 export function resolveOnChange<
   E extends HTMLInputElement | HTMLTextAreaElement,
 >(
@@ -84,8 +94,13 @@ export function resolveOnChange<
   // https://github.com/ant-design/ant-design/issues/45737
   // https://github.com/ant-design/ant-design/issues/46598
   if (target.type !== 'file' && targetValue !== undefined) {
-    event = cloneEvent(e, target, targetValue);
-    onChange(event as React.ChangeEvent<E>);
+    if (target.value !== targetValue) {
+      event = cloneEvent(e, target, targetValue);
+      onChange(event as React.ChangeEvent<E>);
+      return;
+    }
+
+    onChange(cloneEventWithTarget(e, target) as React.ChangeEvent<E>);
     return;
   }
   onChange(event as React.ChangeEvent<E>);

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -96,11 +96,10 @@ export function resolveOnChange<
   if (target.type !== 'file' && targetValue !== undefined) {
     if (target.value !== targetValue) {
       event = cloneEvent(e, target, targetValue);
-      onChange(event as React.ChangeEvent<E>);
-      return;
+    } else {
+      event = cloneEventWithTarget(e, target);
     }
-
-    onChange(cloneEventWithTarget(e, target) as React.ChangeEvent<E>);
+    onChange(event as React.ChangeEvent<E>);
     return;
   }
   onChange(event as React.ChangeEvent<E>);

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -439,6 +439,19 @@ describe('Input ref', () => {
       expect(spySetSelectionRange).toHaveBeenCalledWith(1, 2);
     });
 
+    it('onChange target should be the mounted input when value is unchanged by formatter', () => {
+      const onChange = jest.fn();
+      const { container } = render(<Input onChange={onChange} />);
+      const inputEl = container.querySelector('input')!;
+
+      fireEvent.change(inputEl, { target: { value: 'test' } });
+
+      const event = onChange.mock.calls[0][0];
+      expect(event.target).toBe(inputEl);
+      expect(event.currentTarget).toBe(inputEl);
+      expect(document.contains(event.target)).toBe(true);
+    });
+
     it('email type not support selection', () => {
       const onChange = jest.fn();
       const { container } = render(<Input type="email" onChange={onChange} />);


### PR DESCRIPTION
### Problem

`resolveOnChange` cloned the input element whenever `targetValue` was provided, even when the live input already had that value. This makes ordinary `onChange` events expose a detached `event.target`.

Some custom input integrations, including the `react-number-format` case linked from ant-design/ant-design#46999, expect `event.target` to be the mounted input element.

### Solution

Only use the existing cloned-event path when the reported `targetValue` differs from the live input value. When the values already match, preserve a stable synthetic event wrapper but point `target` and `currentTarget` at the mounted input.

This keeps the existing synthetic-value behavior for clear/composition/formatter paths while avoiding detached targets for ordinary input changes.

### Verification

- Added regression coverage for mounted `onChange` targets.
- `pnpm test -- --runInBand tests/index.test.tsx`
- `pnpm lint`
- `pnpm exec prettier --check src/utils/commonUtils.ts tests/index.test.tsx`

Fixes ant-design/ant-design#46999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 当输入值实际未改变时，避免不必要地覆盖输入框/文本域的值，优化了变更事件触发逻辑以保留原有值。

* **Tests**
  * 新增用例验证 onChange 事件的 target/currentTarget 指向真实挂载的输入元素且仍在文档中，确保事件对象完整性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/input/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->