### PR TITLE
Revert "fix: keep onChange target mounted when value does not need cloning"

### DIFF
--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -45,16 +45,6 @@ function cloneEvent<
   return newEvent;
 }
 
-function cloneEventWithTarget<
-  EventType extends React.SyntheticEvent<any, any>,
-  Element extends HTMLInputElement | HTMLTextAreaElement,
->(event: EventType, target: Element): EventType {
-  return Object.create(event, {
-    target: { value: target },
-    currentTarget: { value: target },
-  });
-}
-
 export function resolveOnChange<
   E extends HTMLInputElement | HTMLTextAreaElement,
 >(
@@ -94,11 +84,7 @@ export function resolveOnChange<
   // https://github.com/ant-design/ant-design/issues/45737
   // https://github.com/ant-design/ant-design/issues/46598
   if (target.type !== 'file' && targetValue !== undefined) {
-    if (target.value !== targetValue) {
-      event = cloneEvent(e, target, targetValue);
-    } else {
-      event = cloneEventWithTarget(e, target);
-    }
+    event = cloneEvent(e, target, targetValue);
     onChange(event as React.ChangeEvent<E>);
     return;
   }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -439,19 +439,6 @@ describe('Input ref', () => {
       expect(spySetSelectionRange).toHaveBeenCalledWith(1, 2);
     });
 
-    it('onChange target should be the mounted input when value is unchanged by formatter', () => {
-      const onChange = jest.fn();
-      const { container } = render(<Input onChange={onChange} />);
-      const inputEl = container.querySelector('input')!;
-
-      fireEvent.change(inputEl, { target: { value: 'test' } });
-
-      const event = onChange.mock.calls[0][0];
-      expect(event.target).toBe(inputEl);
-      expect(event.currentTarget).toBe(inputEl);
-      expect(document.contains(event.target)).toBe(true);
-    });
-
     it('email type not support selection', () => {
       const onChange = jest.fn();
       const { container } = render(<Input type="email" onChange={onChange} />);


### PR DESCRIPTION
Reverts react-component/input#175

The original issue (ant-design/ant-design#46999) has already been fixed in antd v6 — `@rc-component/input@1.3.0` (used since antd 6.4+) properly copies `selectionStart`/`selectionEnd` and proxies `setSelectionRange` to the real input element, which is what `react-number-format` relies on. No additional changes are needed in `resolveOnChange`.

See https://github.com/ant-design/ant-design/issues/46999#issuecomment-4507864963 for details.