### PR TITLE
Expose input internal types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import BaseInput from './BaseInput';
 import Input from './Input';
 import TextArea from './TextArea';
-import type { HolderRef } from './BaseInput';
 
 export type {
   AutoSizeType,
@@ -12,7 +11,7 @@ export type {
   TextAreaProps,
   TextAreaRef,
 } from './interface';
-export type { HolderRef };
+export type { HolderRef } from './BaseInput';
 
 export { default as ResizableTextArea } from './ResizableTextArea';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,18 @@
 import BaseInput from './BaseInput';
 import Input from './Input';
 import TextArea from './TextArea';
+import type { HolderRef } from './BaseInput';
 
 export type {
   AutoSizeType,
+  BaseInputProps,
   InputProps,
   InputRef,
   ResizableTextAreaRef,
   TextAreaProps,
   TextAreaRef,
 } from './interface';
+export type { HolderRef };
 
 export { default as ResizableTextArea } from './ResizableTextArea';
 


### PR DESCRIPTION
## 背景

antd 需要移除对 `@rc-component/input/lib/interface` 的深路径依赖，改为从包根入口导入公开类型。

## 调整内容

- 在根入口导出 `BaseInputProps`，覆盖 antd 当前使用场景。
- 在根入口导出 `HolderRef`，覆盖下游 rc 包对 BaseInput ref 类型的复用需求。

## 验证

- `npm run lint` 通过，仅存在项目已有 warning。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了类型导出结构，改进了代码组织方式。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/input/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->