### PR TITLE
fix: use committed count value during IME composition

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -60,11 +60,14 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     props.defaultValue,
     props.value,
   );
+  // Count-related state should reflect the committed value during IME composition
+  // instead of the intermediate phonetic text.
+  const [countValue, setCountValue] = useState(formatValue);
 
   const countConfig = useCount(count, showCount);
   const { isOutOfRange, dataCount } = useCountDisplay({
     countConfig,
-    value: formatValue,
+    value: countValue,
     maxLength,
   });
   const getExceedValue = useCountExceed({
@@ -99,6 +102,12 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     setFocused((prev) => (prev && disabled ? false : prev));
   }, [disabled]);
 
+  useEffect(() => {
+    if (!compositionRef.current) {
+      setCountValue(formatValue);
+    }
+  }, [formatValue]);
+
   const triggerChange = (
     e:
       | React.ChangeEvent<HTMLInputElement>
@@ -114,6 +123,9 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       return;
     }
     setValue(cutValue);
+    if (!compositionRef.current) {
+      setCountValue(cutValue);
+    }
 
     if (inputRef.current) {
       resolveOnChange(inputRef.current, e, onChange, cutValue);
@@ -227,6 +239,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         type={type}
         onCompositionStart={(e) => {
           compositionRef.current = true;
+          setCountValue(formatValue);
           onCompositionStart?.(e);
         }}
         onCompositionEnd={onInternalCompositionEnd}

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -60,10 +60,13 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const getTextArea = () => resizableTextAreaRef.current?.textArea || null;
 
     const { setValue, formatValue } = useMergedValue(defaultValue, customValue);
+    // Count-related state should reflect the committed value during IME composition
+    // instead of the intermediate phonetic text.
+    const [countValue, setCountValue] = React.useState(formatValue);
     const countConfig = useCount(count, showCount);
     const { isOutOfRange, dataCount } = useCountDisplay({
       countConfig,
-      value: formatValue,
+      value: countValue,
       maxLength,
     });
     const getExceedValue = useCountExceed({
@@ -88,6 +91,12 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       setFocused((prev) => !disabled && prev);
     }, [disabled]);
 
+    useEffect(() => {
+      if (!compositionRef.current) {
+        setCountValue(formatValue);
+      }
+    }, [formatValue]);
+
     // ============================== Count ===============================
     // ============================== Change ==============================
     const triggerChange = (
@@ -98,6 +107,9 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     ) => {
       const cutValue = getExceedValue(currentValue, compositionRef.current);
       setValue(cutValue);
+      if (!compositionRef.current) {
+        setCountValue(cutValue);
+      }
 
       resolveOnChange(e.currentTarget, e, onChange, cutValue);
     };
@@ -107,6 +119,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       HTMLTextAreaElement
     > = (e) => {
       compositionRef.current = true;
+      setCountValue(formatValue);
       onCompositionStart?.(e);
     };
 

--- a/tests/TextArea.count.test.tsx
+++ b/tests/TextArea.count.test.tsx
@@ -129,6 +129,28 @@ describe('TextArea.Count', () => {
     expect(container.querySelector('.rc-textarea-out-of-range')).toBeTruthy();
   });
 
+  it('should base showCount on committed value during IME composition', () => {
+    const { container } = render(
+      <TextArea count={{ show: true, max: 5 }} defaultValue="" />,
+    );
+    const textarea = container.querySelector('textarea')!;
+    const count = container.querySelector('.rc-textarea-data-count');
+
+    expect(count?.textContent).toEqual('0 / 5');
+
+    fireEvent.compositionStart(textarea);
+    fireEvent.change(textarea, { target: { value: 'zhu' } });
+
+    expect(textarea.value).toEqual('zhu');
+    expect(count?.textContent).toEqual('0 / 5');
+
+    fireEvent.compositionEnd(textarea, { currentTarget: { value: '竹' } });
+    fireEvent.input(textarea, { target: { value: '竹' } });
+
+    expect(textarea.value).toEqual('竹');
+    expect(count?.textContent).toEqual('1 / 5');
+  });
+
   describe('cls', () => {
     it('raw', () => {
       const { container } = render(

--- a/tests/count.test.tsx
+++ b/tests/count.test.tsx
@@ -149,6 +149,28 @@ describe('Input.Count', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  it('should base showCount on committed value during IME composition', () => {
+    const { container } = render(
+      <Input count={{ show: true, max: 5 }} defaultValue="" />,
+    );
+    const input = container.querySelector('input')!;
+    const count = container.querySelector('.rc-input-show-count-suffix');
+
+    expect(count?.textContent).toEqual('0 / 5');
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'zhu' } });
+
+    expect(input.value).toEqual('zhu');
+    expect(count?.textContent).toEqual('0 / 5');
+
+    fireEvent.compositionEnd(input, { currentTarget: { value: '竹' } });
+    fireEvent.input(input, { target: { value: '竹' } });
+
+    expect(input.value).toEqual('竹');
+    expect(count?.textContent).toEqual('1 / 5');
+  });
+
   it('using the input method to enter the cropped content should trigger onChange twice', () => {
     const onChange = jest.fn();
     const onCompositionEnd = jest.fn();


### PR DESCRIPTION
## Summary

This change makes `showCount` derive from a committed count value during IME composition instead of the intermediate phonetic text.

## Root Cause

`Input` and `TextArea` updated their count display from the live input value on every change event. During CJK IME composition, that meant `showCount` counted intermediate pinyin text like `zhu` instead of the committed character like `竹`.

## Changes

- add a committed count value for `Input`
- add a committed count value for `TextArea`
- keep `showCount` and count-based out-of-range state aligned with the committed value during IME composition
- add regression tests for `Input` and `TextArea`

## Verification

- `XDG_STATE_HOME=/tmp/codex-watchman-state ./node_modules/.bin/rc-test --runInBand tests/count.test.tsx tests/TextArea.count.test.tsx`
- `XDG_STATE_HOME=/tmp/codex-watchman-state ./node_modules/.bin/rc-test --runInBand`

## Notes

The full test run still prints the existing React `act(...)` warning from `tests/index.test.tsx`, but the suites pass before and after this change.
